### PR TITLE
静的解析ツールの設定

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,12 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": [
+    "eslint:recommended",
+    "next/core-web-vitals",
+    "plugin:react/recommended",
+  ],
+  "rules": {
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/prop-types": "off"
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "eslint:recommended",
     "next/core-web-vitals",
     "plugin:react/recommended",
+    "prettier"
   ],
   "rules": {
     "react/jsx-uses-react": "off",

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -7,4 +7,3 @@
     "trailingComma": "es5",
     "printWidth": 100
 }
-  

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+    "endOfLine": "lf",
+    "semi": true,
+    "singleQuote": true,
+    "jsxSingleQuote": false,
+    "tabWidth": 2,
+    "trailingComma": "es5",
+    "printWidth": 100
+  }
+  

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,5 +6,5 @@
     "tabWidth": 2,
     "trailingComma": "es5",
     "printWidth": 100
-  }
+}
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "styled-components": "^5.3.6"
       },
       "devDependencies": {
+        "eslint-config-prettier": "^8.6.0",
         "prettier": "^2.8.2"
       }
     },
@@ -1601,6 +1602,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -5176,6 +5189,13 @@
         "eslint-plugin-react": "^7.31.7",
         "eslint-plugin-react-hooks": "^4.5.0"
       }
+    },
+    "eslint-config-prettier": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
+    "eslint-config-prettier": "^8.6.0",
     "prettier": "^2.8.2"
   }
 }

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,39 @@
+#!/bin/bash
+   
+echo -e $'\e[1;45m ***** pre-commit hookを実行します ***** \e[m'
+  
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi 
+   
+# Redirect output to stderr.
+exec 1>&2
+SYNTAX_CHECK=0
+   
+## 静的解析、及びフォーマッターの実行
+# コミットされるファイルのうち、.jsで終わるもの
+for FILE in `git diff-index --name-status $against -- | grep -E '^[AUM].*\.js$'| cut -c3-`; do
+    # prettierでの整形
+    echo -e $'\e[36m\nPrettierを実行します \e[m'
+    npx prettier --write $FILE
+    git add $FILE
+
+    # ESLintでのチェック
+    echo -e $'\e[36m\nESLintを実行します \e[m'
+    if ! npx eslint $FILE; then
+        SYNTAX_CHECK=1
+        echo -e $'\e[31;43m ESLintのチェックエラーを直してください \e[m'
+    fi
+done
+
+if [ $SYNTAX_CHECK -eq 0 ]; then
+    echo -e $'\e[42m ***** [OK] No errors ***** \e[m'
+    exit 0
+else
+    echo -e $'\e[31;43m 修正を行った上で再度コミットしてください \e[m'
+    exit 1
+fi

--- a/src/pages/hoge.js
+++ b/src/pages/hoge.js
@@ -1,0 +1,3 @@
+export default function Document() {
+  return <></>;
+}

--- a/src/pages/hoge.js
+++ b/src/pages/hoge.js
@@ -1,3 +1,0 @@
-export default function Document() {
-  return <></>;
-}


### PR DESCRIPTION
- [x] ESLintの設定
* `eslint:recommended`, `next/core-web-vitals`, `react/recomennded`を指定
* reactをインポートする部分とpropsの型指定に関する部分は無効に
* `eslint-config-prettier`を導入して連携
- [x] Prettierの設定
- [x] pre-commitでフック
* prettierでコード整形→整形したファイルをadd→ESLintで解析の流れ